### PR TITLE
build failed on compass in Win7

### DIFF
--- a/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
@@ -267,10 +267,10 @@
             </goals>
             <configuration>
               <target>
-                <property name="compass.executable" value="compass"/>
                 <condition property="compass.executable" value="compass.bat">
                    <os family="windows"/>
                 </condition>
+                <property name="compass.executable" value="compass"/>
                 <exec executable="${symbol_dollar}{compass.executable}" failonerror="true">
                   <arg value="compile"/>
                 </exec>
@@ -285,10 +285,10 @@
             </goals>
             <configuration>
               <target>
-                <property name="compass.executable" value="compass"/>
                 <condition property="compass.executable" value="compass.bat">
                    <os family="windows"/>
                 </condition>
+                <property name="compass.executable" value="compass"/>
                 <exec executable="${symbol_dollar}{compass.executable}" failonerror="true">
                   <arg value="clean"/>
                 </exec>

--- a/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
@@ -271,7 +271,7 @@
                 <condition property="compass.executable" value="compass.bat">
                    <os family="windows"/>
                 </condition>
-                <exec executable="${compass.executable}" failonerror="true">
+                <exec executable="${symbol_dollar}{compass.executable}" failonerror="true">
                   <arg value="compile"/>
                 </exec>
               </target>
@@ -289,7 +289,7 @@
                 <condition property="compass.executable" value="compass.bat">
                    <os family="windows"/>
                 </condition>
-                <exec executable="${compass.executable}" failonerror="true">
+                <exec executable="${symbol_dollar}{compass.executable}" failonerror="true">
                   <arg value="clean"/>
                 </exec>
               </target>

--- a/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
@@ -267,7 +267,11 @@
             </goals>
             <configuration>
               <target>
-                <exec executable="compass" failonerror="true">
+                <property name="compass.executable" value="compass"/>
+                <condition property="compass.executable" value="compass.bat">
+                   <os family="windows"/>
+                </condition>
+                <exec executable="${compass.executable}" failonerror="true">
                   <arg value="compile"/>
                 </exec>
               </target>
@@ -281,7 +285,11 @@
             </goals>
             <configuration>
               <target>
-                <exec executable="compass" failonerror="true">
+                <property name="compass.executable" value="compass"/>
+                <condition property="compass.executable" value="compass.bat">
+                   <os family="windows"/>
+                </condition>
+                <exec executable="${compass.executable}" failonerror="true">
                   <arg value="clean"/>
                 </exec>
               </target>

--- a/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/fiftyfive-wicket-archetype/src/main/resources/archetype-resources/pom.xml
@@ -233,7 +233,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
         <executions>
           <execution>
             <id>prep-settings</id>


### PR DESCRIPTION
When I ran mvn jetty:run, I would get a compile error with compass.  It said that it couldn't run compass in a certain directory.  I went to that directory and could run compass just fine.  Compass was on my path.  I noticed that there was a compass and compass.bat in the ruby/bin folder.  So in the pom.xml I changed compass to compass.bat and fixed the problem.

So either the pom.xml needs to know whether to run compass or compass.bat, or I needed to do something differently with my compass install. 
